### PR TITLE
fix bug - if url length > 22, URI would be wrong

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -635,7 +635,7 @@ uint8_t PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber, uint8_t uriIden
         // 0xFE needs to be wrapped around to next block
         memcpy (sectorbuffer1 + 9, url, len);
         sectorbuffer2[0] = 0xFE;
-    } else if ((len > 7) || (len <= 22)) {
+    } else if ((len > 7) && (len <= 22)) {
         // Url fits in two blocks
         memcpy (sectorbuffer1 + 9, url, 7);
         memcpy (sectorbuffer2, url + 7, len - 7);
@@ -649,8 +649,8 @@ uint8_t PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber, uint8_t uriIden
         // Url fits in three blocks
         memcpy (sectorbuffer1 + 9, url, 7);
         memcpy (sectorbuffer2, url + 7, 16);
-        memcpy (sectorbuffer3, url + 23, len - 24);
-        sectorbuffer3[len - 22] = 0xFE;
+        memcpy (sectorbuffer3, url + 23, len - 23);
+        sectorbuffer3[len - 23] = 0xFE;
     }
 
     // Now write all three blocks back to the card


### PR DESCRIPTION
If you run "mifareclassic_formatndef" or "mifareclassic_updatendef" examples with an url longer than 22 character, before this commit your program would enter the if loop between line 638 and line 642, which cause NDEF reader not even able to recognize the formatted card. Also indexing in line 652 and 653 was not correct either.